### PR TITLE
Implement CanActivate

### DIFF
--- a/src/common_router_providers.ts
+++ b/src/common_router_providers.ts
@@ -3,7 +3,7 @@ import { UrlSerializer, DefaultUrlSerializer } from './url_serializer';
 import { ActivatedRoute } from './router_state';
 import { Router } from './router';
 import { RouterConfig } from './config';
-import { ComponentResolver, ApplicationRef} from '@angular/core';
+import { ComponentResolver, ApplicationRef, Injector } from '@angular/core';
 import { LocationStrategy, PathLocationStrategy, Location } from '@angular/common';
 
 /**
@@ -32,17 +32,17 @@ export function provideRouter(config: RouterConfig):any[] {
 
     {
       provide: Router,
-      useFactory: (ref, resolver, urlSerializer, outletMap, location) => {
+      useFactory: (ref, resolver, urlSerializer, outletMap, location, injector) => {
         if (ref.componentTypes.length == 0) {
           throw new Error("Bootstrap at least one component before injecting Router.");
         }
         const componentType = ref.componentTypes[0];
-        const r = new Router(componentType, resolver, urlSerializer, outletMap, location);
+        const r = new Router(componentType, resolver, urlSerializer, outletMap, location, injector);
         r.resetConfig(config);
         ref.registerDisposeListener(() => r.dispose());
         return r;
       },
-      deps: [ApplicationRef, ComponentResolver, UrlSerializer, RouterOutletMap, Location]
+      deps: [ApplicationRef, ComponentResolver, UrlSerializer, RouterOutletMap, Location, Injector]
     },
 
     RouterOutletMap,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,5 +7,6 @@ export interface Route {
   path?: string;
   component: Type | string;
   outlet?: string;
+  canActivate?: any[],
   children?: Route[];
 }

--- a/src/create_router_state.ts
+++ b/src/create_router_state.ts
@@ -1,0 +1,42 @@
+import { RouterStateCandidate, ActivatedRouteCandidate, RouterState, ActivatedRoute } from './router_state';
+import { TreeNode } from './utils/tree';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+
+export function createRouterState(curr: RouterStateCandidate, prev: RouterStateCandidate, prevState: RouterState): RouterState {
+  const root = createNode(curr._root, prev ? prev._root : null, prevState ? prevState._root : null);
+  const queryParams = prevState ? prevState.queryParams : new BehaviorSubject(curr.queryParams);
+  const fragment = prevState ? prevState.fragment : new BehaviorSubject(curr.fragment);
+  return new RouterState(root, queryParams, fragment);
+}
+
+function createNode(curr:TreeNode<ActivatedRouteCandidate>, prev?:TreeNode<ActivatedRouteCandidate>, prevState?:TreeNode<ActivatedRoute>):TreeNode<ActivatedRoute> {
+  if (prev && equalRouteCandidates(prev.value, curr.value)) {
+    const value = prevState.value;
+    const children = createOrReuseChildren(curr, prev, prevState);
+    return new TreeNode<ActivatedRoute>(value, children);
+
+  } else {
+    const value = createActivatedRoute(curr.value);
+    const children = curr.children.map(c => createNode(c));
+    return new TreeNode<ActivatedRoute>(value, children);
+  }
+}
+
+function createOrReuseChildren(curr:TreeNode<ActivatedRouteCandidate>, prev:TreeNode<ActivatedRouteCandidate>, prevState:TreeNode<ActivatedRoute>) {
+  return curr.children.map(child => {
+    const index = prev.children.findIndex(p => equalRouteCandidates(p.value, child.value));
+    if (index >= 0) {
+      return createNode(child, prev.children[index], prevState.children[index]);
+    } else {
+      return createNode(child);
+    }
+  });
+}
+
+function createActivatedRoute(c:ActivatedRouteCandidate) {
+  return new ActivatedRoute(new BehaviorSubject(c.urlSegments), new BehaviorSubject(c.params), c.outlet, c.component);
+}
+
+function equalRouteCandidates(a: ActivatedRouteCandidate, b: ActivatedRouteCandidate): boolean {
+  return a._routeConfig === b._routeConfig;
+}

--- a/src/create_router_state.ts
+++ b/src/create_router_state.ts
@@ -1,18 +1,18 @@
-import { RouterStateCandidate, ActivatedRouteCandidate, RouterState, ActivatedRoute } from './router_state';
+import { RouterStateSnapshot, ActivatedRouteSnapshot, RouterState, ActivatedRoute } from './router_state';
 import { TreeNode } from './utils/tree';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-export function createRouterState(curr: RouterStateCandidate, prevState: RouterState): RouterState {
+export function createRouterState(curr: RouterStateSnapshot, prevState: RouterState): RouterState {
   const root = createNode(curr._root, prevState ? prevState._root : null);
   const queryParams = prevState ? prevState.queryParams : new BehaviorSubject(curr.queryParams);
   const fragment = prevState ? prevState.fragment : new BehaviorSubject(curr.fragment);
   return new RouterState(root, queryParams, fragment, curr);
 }
 
-function createNode(curr:TreeNode<ActivatedRouteCandidate>, prevState?:TreeNode<ActivatedRoute>):TreeNode<ActivatedRoute> {
-  if (prevState && equalRouteCandidates(prevState.value.candidate, curr.value)) {
+function createNode(curr:TreeNode<ActivatedRouteSnapshot>, prevState?:TreeNode<ActivatedRoute>):TreeNode<ActivatedRoute> {
+  if (prevState && equalRouteSnapshots(prevState.value.snapshot, curr.value)) {
     const value = prevState.value;
-    value.candidate = curr.value;
+    value.snapshot = curr.value;
     
     const children = createOrReuseChildren(curr, prevState);
     return new TreeNode<ActivatedRoute>(value, children);
@@ -24,9 +24,9 @@ function createNode(curr:TreeNode<ActivatedRouteCandidate>, prevState?:TreeNode<
   }
 }
 
-function createOrReuseChildren(curr:TreeNode<ActivatedRouteCandidate>, prevState:TreeNode<ActivatedRoute>) {
+function createOrReuseChildren(curr:TreeNode<ActivatedRouteSnapshot>, prevState:TreeNode<ActivatedRoute>) {
   return curr.children.map(child => {
-    const index = prevState.children.findIndex(p => equalRouteCandidates(p.value.candidate, child.value));
+    const index = prevState.children.findIndex(p => equalRouteSnapshots(p.value.snapshot, child.value));
     if (index >= 0) {
       return createNode(child, prevState.children[index]);
     } else {
@@ -35,10 +35,10 @@ function createOrReuseChildren(curr:TreeNode<ActivatedRouteCandidate>, prevState
   });
 }
 
-function createActivatedRoute(c:ActivatedRouteCandidate) {
+function createActivatedRoute(c:ActivatedRouteSnapshot) {
   return new ActivatedRoute(new BehaviorSubject(c.urlSegments), new BehaviorSubject(c.params), c.outlet, c.component, c);
 }
 
-function equalRouteCandidates(a: ActivatedRouteCandidate, b: ActivatedRouteCandidate): boolean {
+function equalRouteSnapshots(a: ActivatedRouteSnapshot, b: ActivatedRouteSnapshot): boolean {
   return a._routeConfig === b._routeConfig;
 }

--- a/src/create_router_state.ts
+++ b/src/create_router_state.ts
@@ -3,7 +3,7 @@ import { TreeNode } from './utils/tree';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 export function createRouterState(curr: RouterStateSnapshot, prevState: RouterState): RouterState {
-  const root = createNode(curr._root, prevState ? prevState._root : null);
+  const root = createNode(curr._root, prevState ? prevState._root : undefined);
   const queryParams = prevState ? prevState.queryParams : new BehaviorSubject(curr.queryParams);
   const fragment = prevState ? prevState.fragment : new BehaviorSubject(curr.fragment);
   return new RouterState(root, queryParams, fragment, curr);

--- a/src/create_url_tree.ts
+++ b/src/create_url_tree.ts
@@ -96,8 +96,7 @@ function findStartingNode(normalizedChange: NormalizedNavigationCommands, urlTre
 }
 
 function findUrlSegment(route: ActivatedRoute, urlTree: UrlTree, numberOfDoubleDots: number): UrlSegment {
-  const segments = (<any>route.urlSegments).value;
-  const urlSegment = segments[segments.length - 1];
+  const urlSegment = route.snapshot._lastUrlSegment;
   const path = urlTree.pathFromRoot(urlSegment);
   if (path.length <= numberOfDoubleDots) {
     throw new Error("Invalid number of '../'");

--- a/src/create_url_tree.ts
+++ b/src/create_url_tree.ts
@@ -1,5 +1,5 @@
 import { UrlTree, UrlSegment, equalUrlSegments } from './url_tree';
-import { TreeNode, rootNode } from './utils/tree';
+import { TreeNode } from './utils/tree';
 import { forEach, shallowEqual } from './utils/collection';
 import { RouterState, ActivatedRoute } from './router_state';
 import { Params, PRIMARY_OUTLET } from './shared';
@@ -7,7 +7,7 @@ import { Params, PRIMARY_OUTLET } from './shared';
 export function createUrlTree(route: ActivatedRoute, urlTree: UrlTree, commands: any[], 
                               queryParameters: Params | undefined, fragment: string | undefined): UrlTree {
   if (commands.length === 0) {
-    return tree(rootNode(urlTree), urlTree, queryParameters, fragment);
+    return tree(urlTree._root, urlTree, queryParameters, fragment);
   }
 
   const normalizedCommands = normalizeCommands(commands);
@@ -19,7 +19,7 @@ export function createUrlTree(route: ActivatedRoute, urlTree: UrlTree, commands:
   const updated = normalizedCommands.commands.length > 0 ?
       updateMany(startingNode.children.slice(0), normalizedCommands.commands) :
       [];
-  const newRoot = constructNewTree(rootNode(urlTree), startingNode, updated);
+  const newRoot = constructNewTree(urlTree._root, startingNode, updated);
 
   return tree(newRoot, urlTree, queryParameters, fragment);
 }
@@ -87,11 +87,11 @@ function normalizeCommands(commands: any[]): NormalizedNavigationCommands {
 function findStartingNode(normalizedChange: NormalizedNavigationCommands, urlTree: UrlTree,
                            route: ActivatedRoute): TreeNode<UrlSegment> {
   if (normalizedChange.isAbsolute) {
-    return rootNode(urlTree);
+    return urlTree._root;
   } else {
     const urlSegment =
       findUrlSegment(route, urlTree, normalizedChange.numberOfDoubleDots);
-    return findMatchingNode(urlSegment, rootNode(urlTree));
+    return findMatchingNode(urlSegment, urlTree._root);
   }
 }
 

--- a/src/directives/router_outlet.ts
+++ b/src/directives/router_outlet.ts
@@ -1,4 +1,4 @@
-import {Directive, ViewContainerRef, Attribute, ComponentRef, ComponentFactory, ResolvedReflectiveProvider, ReflectiveInjector} from '@angular/core';
+import {Injector, Directive, ViewContainerRef, Attribute, ComponentRef, ComponentFactory, ResolvedReflectiveProvider, ReflectiveInjector} from '@angular/core';
 import {RouterOutletMap} from '../router_outlet_map';
 import {PRIMARY_OUTLET} from '../shared';
 
@@ -8,7 +8,7 @@ export class RouterOutlet {
   public outletMap:RouterOutletMap;
 
   constructor(parentOutletMap:RouterOutletMap, private location:ViewContainerRef,
-              @Attribute('name') name:string) {
+              @Attribute('name') name:string, public injector: Injector) {
     parentOutletMap.registerOutlet(name ? name : PRIMARY_OUTLET, this);
   }
 

--- a/src/recognize.ts
+++ b/src/recognize.ts
@@ -174,7 +174,7 @@ class MatchResult {
               public leftOverUrl: TreeNode<UrlSegment>[],
               public secondary: TreeNode<UrlSegment>[],
               public outlet: string,
-              public route: Route,
+              public route: Route | null,
               public lastUrlSegment: UrlSegment
   ) {}
 }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,0 +1,28 @@
+import { RouterStateCandidate, ActivatedRouteCandidate } from './router_state';
+import { TreeNode } from './utils/tree';
+import { ComponentResolver } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
+import {forkJoin} from 'rxjs/observable/forkJoin';
+import {fromPromise} from 'rxjs/observable/fromPromise';
+import 'rxjs/add/operator/toPromise';
+
+export function resolve(resolver: ComponentResolver, state: RouterStateCandidate): Observable<RouterStateCandidate> {
+  return resolveNode(resolver, state._root).map(_ => state);
+}
+
+function resolveNode(resolver: ComponentResolver, node: TreeNode<ActivatedRouteCandidate>): Observable<any> {
+  if (node.children.length === 0) {
+    return fromPromise(resolver.resolveComponent(<any>node.value.component).then(factory => {
+      node.value._resolvedComponentFactory = factory;
+      return node.value;
+    }));
+    
+  } else {
+    const c = node.children.map(c => resolveNode(resolver, c).toPromise());
+    return forkJoin(c).map(_ => resolver.resolveComponent(<any>node.value.component).then(factory => {
+      node.value._resolvedComponentFactory = factory;
+      return node.value;
+    }));
+  }
+}

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,4 +1,4 @@
-import { RouterStateCandidate, ActivatedRouteCandidate } from './router_state';
+import { RouterStateSnapshot, ActivatedRouteSnapshot } from './router_state';
 import { TreeNode } from './utils/tree';
 import { ComponentResolver } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
@@ -7,11 +7,11 @@ import {forkJoin} from 'rxjs/observable/forkJoin';
 import {fromPromise} from 'rxjs/observable/fromPromise';
 import 'rxjs/add/operator/toPromise';
 
-export function resolve(resolver: ComponentResolver, state: RouterStateCandidate): Observable<RouterStateCandidate> {
+export function resolve(resolver: ComponentResolver, state: RouterStateSnapshot): Observable<RouterStateSnapshot> {
   return resolveNode(resolver, state._root).map(_ => state);
 }
 
-function resolveNode(resolver: ComponentResolver, node: TreeNode<ActivatedRouteCandidate>): Observable<any> {
+function resolveNode(resolver: ComponentResolver, node: TreeNode<ActivatedRouteSnapshot>): Observable<any> {
   if (node.children.length === 0) {
     return fromPromise(resolver.resolveComponent(<any>node.value.component).then(factory => {
       node.value._resolvedComponentFactory = factory;

--- a/src/router.ts
+++ b/src/router.ts
@@ -218,15 +218,15 @@ class GuardChecks {
     const future = futureNode.value;
     const curr = currNode ? currNode.value : null;
 
-    if (future === curr) {
+    if (curr && future === curr) {
       if (!shallowEqual(future.params, curr.params)) {
         this.checks.push(future);
       }
-      this.traverseChildRoutes(futureNode, currNode, null);
+      this.traverseChildRoutes(futureNode, currNode, <any>null);
     } else {
-      this.deactivateOutletAndItChildren(null);
+      this.deactivateOutletAndItChildren(<any>null);
       this.checks.push(future);
-      this.traverseChildRoutes(futureNode, null, null);
+      this.traverseChildRoutes(futureNode, null, <any>null);
     }
   }
 

--- a/src/router_state.ts
+++ b/src/router_state.ts
@@ -22,21 +22,22 @@ import { Type, ComponentFactory } from '@angular/core';
  * ```
  */
 export class RouterState extends Tree<ActivatedRoute> {
-  constructor(root: TreeNode<ActivatedRoute>, public queryParams: Observable<Params>, public fragment: Observable<string>) {
+  constructor(root: TreeNode<ActivatedRoute>, public queryParams: Observable<Params>, public fragment: Observable<string>, public candidate: RouterStateCandidate) {
     super(root);
   }
 }
 
 export function createEmptyState(rootComponent: Type): RouterState {
+  const candidate = createEmptyStateCandidate(rootComponent);
   const emptyUrl = new BehaviorSubject([new UrlSegment("", {}, PRIMARY_OUTLET)]);
   const emptyParams = new BehaviorSubject({});
   const emptyQueryParams = new BehaviorSubject({});
   const fragment = new BehaviorSubject("");
-  const activated = new ActivatedRoute(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent);
-  return new RouterState(new TreeNode<ActivatedRoute>(activated, []), emptyQueryParams, fragment);
+  const activated = new ActivatedRoute(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, candidate.root);
+  return new RouterState(new TreeNode<ActivatedRoute>(activated, []), emptyQueryParams, fragment, candidate);
 }
 
-export function createEmptyStateCandidate(rootComponent: Type): RouterStateCandidate {
+function createEmptyStateCandidate(rootComponent: Type): RouterStateCandidate {
   const emptyUrl = [new UrlSegment("", {}, PRIMARY_OUTLET)];
   const emptyParams = {};
   const emptyQueryParams = {};
@@ -62,7 +63,9 @@ export class ActivatedRoute {
   constructor(public urlSegments: Observable<UrlSegment[]>,
               public params: Observable<Params>,
               public outlet: string,
-              public component: Type | string) {}
+              public component: Type | string,
+              public candidate: ActivatedRouteCandidate
+  ) {}
 }
 
 export class ActivatedRouteCandidate {

--- a/src/router_state.ts
+++ b/src/router_state.ts
@@ -90,7 +90,7 @@ export class ActivatedRouteSnapshot {
   _resolvedComponentFactory: ComponentFactory<any>;
   
   /** @internal **/
-  _routeConfig: Route;
+  _routeConfig: Route | null;
 
   /** @internal **/
   _lastUrlSegment: UrlSegment;
@@ -99,7 +99,7 @@ export class ActivatedRouteSnapshot {
               public params: Params,
               public outlet: string,
               public component: Type | string, 
-              routeConfig: Route,
+              routeConfig: Route | null,
               lastUrlSegment: UrlSegment) {
     this._routeConfig = routeConfig;
     this._lastUrlSegment = lastUrlSegment;
@@ -120,7 +120,7 @@ export class ActivatedRouteSnapshot {
  * ```
  */
 export class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
-  constructor(root: TreeNode<ActivatedRouteSnapshot>, public queryParams: Params, public fragment: string) {
+  constructor(root: TreeNode<ActivatedRouteSnapshot>, public queryParams: Params, public fragment: string | null) {
     super(root);
   }
 }

--- a/src/router_state.ts
+++ b/src/router_state.ts
@@ -1,9 +1,10 @@
 import { Tree, TreeNode } from './utils/tree';
 import { UrlSegment } from './url_tree';
+import { Route } from './config';
 import { Params, PRIMARY_OUTLET } from './shared';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Type } from '@angular/core';
+import { Type, ComponentFactory } from '@angular/core';
 
 /**
  * The state of the router at a particular moment in time.
@@ -35,6 +36,15 @@ export function createEmptyState(rootComponent: Type): RouterState {
   return new RouterState(new TreeNode<ActivatedRoute>(activated, []), emptyQueryParams, fragment);
 }
 
+export function createEmptyStateCandidate(rootComponent: Type): RouterStateCandidate {
+  const emptyUrl = [new UrlSegment("", {}, PRIMARY_OUTLET)];
+  const emptyParams = {};
+  const emptyQueryParams = {};
+  const fragment = "";
+  const activated = new ActivatedRouteCandidate(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, null);
+  return new RouterStateCandidate(new TreeNode<ActivatedRouteCandidate>(activated, []), emptyQueryParams, fragment);
+}
+
 /**
  * Contains the information about a component loaded in an outlet.
  *
@@ -53,4 +63,28 @@ export class ActivatedRoute {
               public params: Observable<Params>,
               public outlet: string,
               public component: Type | string) {}
+}
+
+export class ActivatedRouteCandidate {
+  /**
+   * @internal
+   */
+  _resolvedComponentFactory: ComponentFactory<any>;
+  
+  /** @internal **/
+  _routeConfig: Route;
+
+  constructor(public urlSegments: UrlSegment[],
+              public params: Params,
+              public outlet: string,
+              public component: Type | string, 
+              routeConfig: Route) {
+    this._routeConfig = routeConfig;
+  }
+}
+
+export class RouterStateCandidate extends Tree<ActivatedRouteCandidate> {
+  constructor(root: TreeNode<ActivatedRouteCandidate>, public queryParams: Params, public fragment: string) {
+    super(root);
+  }
 }

--- a/src/router_state.ts
+++ b/src/router_state.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Type, ComponentFactory } from '@angular/core';
 
 /**
- * The state of the router at a particular moment in time.
+ * The state of the router.
  *
  * ### Usage
  *
@@ -22,32 +22,33 @@ import { Type, ComponentFactory } from '@angular/core';
  * ```
  */
 export class RouterState extends Tree<ActivatedRoute> {
-  constructor(root: TreeNode<ActivatedRoute>, public queryParams: Observable<Params>, public fragment: Observable<string>, public candidate: RouterStateCandidate) {
+  constructor(root: TreeNode<ActivatedRoute>, public queryParams: Observable<Params>, public fragment: Observable<string>, public snapshot: RouterStateSnapshot) {
     super(root);
   }
 }
 
 export function createEmptyState(rootComponent: Type): RouterState {
-  const candidate = createEmptyStateCandidate(rootComponent);
+  const snapshot = createEmptyStateSnapshot(rootComponent);
   const emptyUrl = new BehaviorSubject([new UrlSegment("", {}, PRIMARY_OUTLET)]);
   const emptyParams = new BehaviorSubject({});
   const emptyQueryParams = new BehaviorSubject({});
   const fragment = new BehaviorSubject("");
-  const activated = new ActivatedRoute(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, candidate.root);
-  return new RouterState(new TreeNode<ActivatedRoute>(activated, []), emptyQueryParams, fragment, candidate);
+  const activated = new ActivatedRoute(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, snapshot.root);
+  return new RouterState(new TreeNode<ActivatedRoute>(activated, []), emptyQueryParams, fragment, snapshot);
 }
 
-function createEmptyStateCandidate(rootComponent: Type): RouterStateCandidate {
+function createEmptyStateSnapshot(rootComponent: Type): RouterStateSnapshot {
   const emptyUrl = [new UrlSegment("", {}, PRIMARY_OUTLET)];
   const emptyParams = {};
   const emptyQueryParams = {};
   const fragment = "";
-  const activated = new ActivatedRouteCandidate(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, null);
-  return new RouterStateCandidate(new TreeNode<ActivatedRouteCandidate>(activated, []), emptyQueryParams, fragment);
+  const activated = new ActivatedRouteSnapshot(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, null);
+  return new RouterStateSnapshot(new TreeNode<ActivatedRouteSnapshot>(activated, []), emptyQueryParams, fragment);
 }
 
 /**
- * Contains the information about a component loaded in an outlet.
+ * Contains the information about a component loaded in an outlet. The information is provided through
+ * the params and urlSegments observables.
  *
  * ### Usage
  *
@@ -64,11 +65,24 @@ export class ActivatedRoute {
               public params: Observable<Params>,
               public outlet: string,
               public component: Type | string,
-              public candidate: ActivatedRouteCandidate
+              public snapshot: ActivatedRouteSnapshot
   ) {}
 }
 
-export class ActivatedRouteCandidate {
+/**
+ * Contains the information about a component loaded in an outlet at a particular moment in time.
+ *
+ * ### Usage
+ *
+ * ```
+ * class MyComponent {
+ *   constructor(route: ActivatedRoute) {
+ *     const id: string = route.snapshot.params.id;
+ *   }
+ * }
+ * ```
+ */
+export class ActivatedRouteSnapshot {
   /**
    * @internal
    */
@@ -86,8 +100,21 @@ export class ActivatedRouteCandidate {
   }
 }
 
-export class RouterStateCandidate extends Tree<ActivatedRouteCandidate> {
-  constructor(root: TreeNode<ActivatedRouteCandidate>, public queryParams: Params, public fragment: string) {
+/**
+ * The state of the router at a particular moment in time.
+ *
+ * ### Usage
+ *
+ * ```
+ * class MyComponent {
+ *   constructor(router: Router) {
+ *     const snapshot = router.routerState.snapshot;
+ *   }
+ * }
+ * ```
+ */
+export class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
+  constructor(root: TreeNode<ActivatedRouteSnapshot>, public queryParams: Params, public fragment: string) {
     super(root);
   }
 }

--- a/src/router_state.ts
+++ b/src/router_state.ts
@@ -38,11 +38,12 @@ export function createEmptyState(rootComponent: Type): RouterState {
 }
 
 function createEmptyStateSnapshot(rootComponent: Type): RouterStateSnapshot {
-  const emptyUrl = [new UrlSegment("", {}, PRIMARY_OUTLET)];
+  const rootUrlSegment = new UrlSegment("", {}, PRIMARY_OUTLET);
+  const emptyUrl = [rootUrlSegment];
   const emptyParams = {};
   const emptyQueryParams = {};
   const fragment = "";
-  const activated = new ActivatedRouteSnapshot(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, null);
+  const activated = new ActivatedRouteSnapshot(emptyUrl, emptyParams, PRIMARY_OUTLET, rootComponent, null, rootUrlSegment);
   return new RouterStateSnapshot(new TreeNode<ActivatedRouteSnapshot>(activated, []), emptyQueryParams, fragment);
 }
 
@@ -91,12 +92,17 @@ export class ActivatedRouteSnapshot {
   /** @internal **/
   _routeConfig: Route;
 
+  /** @internal **/
+  _lastUrlSegment: UrlSegment;
+
   constructor(public urlSegments: UrlSegment[],
               public params: Params,
               public outlet: string,
               public component: Type | string, 
-              routeConfig: Route) {
+              routeConfig: Route,
+              lastUrlSegment: UrlSegment) {
     this._routeConfig = routeConfig;
+    this._lastUrlSegment = lastUrlSegment;
   }
 }
 

--- a/src/url_serializer.ts
+++ b/src/url_serializer.ts
@@ -1,6 +1,6 @@
 import { UrlTree, UrlSegment } from './url_tree';
 import { PRIMARY_OUTLET } from './shared';
-import { rootNode, TreeNode } from './utils/tree';
+import { TreeNode } from './utils/tree';
 
 /**
  * Defines a way to serialize/deserialize a url tree.
@@ -27,7 +27,7 @@ export class DefaultUrlSerializer implements UrlSerializer {
   }
 
   serialize(tree: UrlTree): string { 
-    const node = serializeUrlTreeNode(rootNode(tree));
+    const node = serializeUrlTreeNode(tree._root);
     const query = serializeQueryParams(tree.queryParameters);
     const fragment = tree.fragment !== null ? `#${tree.fragment}` : '';
     return `${node}${query}${fragment}`;

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -28,6 +28,10 @@ export function first<T>(a: T[]): T | null {
   return a.length > 0 ? a[0] : null;
 }
 
+export function and(bools: boolean[]): boolean {
+  return bools.reduce((a,b) => a && b, true);
+}
+
 export function merge<V>(m1: {[key: string]: V}, m2: {[key: string]: V}): {[key: string]: V} {
   var m: {[key: string]: V} = {};
 

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -34,10 +34,6 @@ export class Tree<T> {
   contains(tree: Tree<T>): boolean { return contains(this._root, tree._root); }
 }
 
-export function rootNode<T>(tree: Tree<T>): TreeNode<T> {
-  return tree._root;
-}
-
 function findNode<T>(expected: T, c: TreeNode<T>): TreeNode<T> | null {
   if (expected === c.value) return c;
   for (let cc of c.children) {

--- a/test/create_router_state.spec.ts
+++ b/test/create_router_state.spec.ts
@@ -1,13 +1,12 @@
 import {DefaultUrlSerializer} from '../src/url_serializer';
 import {UrlTree} from '../src/url_tree';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
-import {ActivatedRoute, ActivatedRouteCandidate, RouterStateCandidate, createEmptyStateCandidate, createEmptyState} from '../src/router_state';
+import {ActivatedRoute, ActivatedRouteCandidate, RouterStateCandidate, createEmptyState} from '../src/router_state';
 import {createRouterState} from '../src/create_router_state';
 import {recognize} from '../src/recognize';
 import {RouterConfig} from '../src/config';
 
 describe('create router state', () => {
-  const emptyCandidate = () => createEmptyStateCandidate(RootComponent);
   const emptyState = () => createEmptyState(RootComponent);
 
   it('should work create new state', () => {
@@ -15,7 +14,7 @@ describe('create router state', () => {
       {path: 'a', component: ComponentA},
       {path: 'b', component: ComponentB, outlet: 'left'},
       {path: 'c', component: ComponentC, outlet: 'right'}
-    ], "a(left:b//right:c)"), emptyCandidate(), emptyState());
+    ], "a(left:b//right:c)"), emptyState());
 
     checkActivatedRoute(state.root, RootComponent);
 
@@ -32,10 +31,8 @@ describe('create router state', () => {
       {path: 'c', component: ComponentC, outlet: 'left'}
     ];
 
-    const prevCandidate = createState(config, "a(left:b)");
-    const prevState = createRouterState(prevCandidate, emptyCandidate(), emptyState());
-
-    const state = createRouterState(createState(config, "a(left:c)"), prevCandidate, prevState);
+    const prevState = createRouterState(createState(config, "a(left:b)"), emptyState());
+    const state = createRouterState(createState(config, "a(left:c)"), prevState);
 
     expect(prevState.root).toBe(state.root);
     const prevC = prevState.children(prevState.root);

--- a/test/create_router_state.spec.ts
+++ b/test/create_router_state.spec.ts
@@ -1,7 +1,7 @@
 import {DefaultUrlSerializer} from '../src/url_serializer';
 import {UrlTree} from '../src/url_tree';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
-import {ActivatedRoute, ActivatedRouteCandidate, RouterStateCandidate, createEmptyState} from '../src/router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot, RouterStateSnapshot, createEmptyState} from '../src/router_state';
 import {createRouterState} from '../src/create_router_state';
 import {recognize} from '../src/recognize';
 import {RouterConfig} from '../src/config';
@@ -44,7 +44,7 @@ describe('create router state', () => {
   });
 });
 
-function createState(config: RouterConfig, url: string): RouterStateCandidate {
+function createState(config: RouterConfig, url: string): RouterStateSnapshot {
   let res;
   recognize(RootComponent, config, tree(url)).forEach(s => res = s);
   return res;

--- a/test/create_url_tree.spec.ts
+++ b/test/create_url_tree.spec.ts
@@ -175,6 +175,6 @@ function create(start: UrlSegment | null, tree: UrlTree, commands: any[], queryP
   if (!start) {
     expect(start).toBeDefined();
   }
-  const a = new ActivatedRoute(new BehaviorSubject([start]), <any>null, PRIMARY_OUTLET, "someComponent");
+  const a = new ActivatedRoute(new BehaviorSubject([start]), <any>null, PRIMARY_OUTLET, "someComponent", null);
   return createUrlTree(a, tree, commands, queryParameters, fragment);
 }

--- a/test/create_url_tree.spec.ts
+++ b/test/create_url_tree.spec.ts
@@ -1,9 +1,8 @@
 import {DefaultUrlSerializer} from '../src/url_serializer';
 import {UrlTree, UrlSegment} from '../src/url_tree';
-import {ActivatedRoute} from '../src/router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot} from '../src/router_state';
 import {PRIMARY_OUTLET, Params} from '../src/shared';
 import {createUrlTree} from '../src/create_url_tree';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 describe('createUrlTree', () => {
   const serializer = new DefaultUrlSerializer();
@@ -175,6 +174,7 @@ function create(start: UrlSegment | null, tree: UrlTree, commands: any[], queryP
   if (!start) {
     expect(start).toBeDefined();
   }
-  const a = new ActivatedRoute(new BehaviorSubject([start]), <any>null, PRIMARY_OUTLET, "someComponent", null);
+  const s = new ActivatedRouteSnapshot([], <any>null, PRIMARY_OUTLET, "someComponent", null, start);
+  const a = new ActivatedRoute(<any>null, <any>null, PRIMARY_OUTLET, "someComponent", s);
   return createUrlTree(a, tree, commands, queryParameters, fragment);
 }

--- a/test/create_url_tree.spec.ts
+++ b/test/create_url_tree.spec.ts
@@ -174,7 +174,7 @@ function create(start: UrlSegment | null, tree: UrlTree, commands: any[], queryP
   if (!start) {
     expect(start).toBeDefined();
   }
-  const s = new ActivatedRouteSnapshot([], <any>null, PRIMARY_OUTLET, "someComponent", null, start);
+  const s = new ActivatedRouteSnapshot([], <any>null, PRIMARY_OUTLET, "someComponent", null, <any>start);
   const a = new ActivatedRoute(<any>null, <any>null, PRIMARY_OUTLET, "someComponent", s);
   return createUrlTree(a, tree, commands, queryParameters, fragment);
 }

--- a/test/recognize.spec.ts
+++ b/test/recognize.spec.ts
@@ -202,7 +202,7 @@ describe('recognize', () => {
         { path: 'a', component: ComponentA },
         { path: 'b', component: ComponentB, outlet: 'aux' },
         { path: 'c', component: ComponentC, outlet: 'aux' }
-      ], tree("a(aux:b//aux:c)")).subscribe(null, s => {
+      ], tree("a(aux:b//aux:c)")).subscribe((_) => {}, s => {
         expect(s.toString()).toContain("Two segments cannot have the same outlet name: 'aux:b' and 'aux:c'.");
       });
     });
@@ -210,7 +210,7 @@ describe('recognize', () => {
     it("should error when no matching routes", () => {
       recognize(RootComponent, [
         { path: 'a', component: ComponentA }
-      ], tree("invalid")).subscribe(null, s => {
+      ], tree("invalid")).subscribe((_) => {}, s => {
         expect(s.toString()).toContain("Cannot match any routes");
       });
     });
@@ -218,7 +218,7 @@ describe('recognize', () => {
     it("should error when no matching routes (too short)", () => {
       recognize(RootComponent, [
         { path: 'a/:id', component: ComponentA }
-      ], tree("a")).subscribe(null, s => {
+      ], tree("a")).subscribe((_) => {}, s => {
         expect(s.toString()).toContain("Cannot match any routes");
       });
     });

--- a/test/recognize.spec.ts
+++ b/test/recognize.spec.ts
@@ -1,7 +1,7 @@
 import {DefaultUrlSerializer} from '../src/url_serializer';
 import {UrlTree} from '../src/url_tree';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
-import {ActivatedRouteCandidate} from '../src/router_state';
+import {ActivatedRouteSnapshot} from '../src/router_state';
 import {recognize} from '../src/recognize';
 
 describe('recognize', () => {
@@ -196,7 +196,7 @@ describe('recognize', () => {
   });
 });
 
-function checkActivatedRoute(actual: ActivatedRouteCandidate | null, url: string, params: Params, cmp: Function, outlet: string = PRIMARY_OUTLET):void {
+function checkActivatedRoute(actual: ActivatedRouteSnapshot | null, url: string, params: Params, cmp: Function, outlet: string = PRIMARY_OUTLET):void {
   if (actual === null) {
     expect(actual).toBeDefined();
   } else {

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -1,6 +1,7 @@
 import {Component, Injector} from '@angular/core';
 import {
   describe,
+  ddescribe,
   it,
   iit,
   xit,
@@ -197,6 +198,26 @@ describe("Integration", () => {
 
       expect(team.recordedParams).toEqual([{id: '22'}]);
       expect(user.recordedParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
+    })));
+
+  it('should work when navigating to /',
+    fakeAsync(inject([Router, TestComponentBuilder], (router, tcb:TestComponentBuilder) => {
+      router.resetConfig([
+        { index: true, component: SimpleCmp },
+        { path: '/user/:name', component: UserCmp }
+      ]);
+
+      const fixture = tcb.createFakeAsync(RootCmp);
+
+      router.navigateByUrl('/user/victor');
+      advance(fixture);
+
+      expect(fixture.debugElement.nativeElement).toHaveText('user victor');
+
+      router.navigateByUrl('/');
+      advance(fixture);
+
+      expect(fixture.debugElement.nativeElement).toHaveText('simple');
     })));
 
   describe("router links", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "noEmitOnError": false,
     "module": "commonjs",
     "target": "es5",
     "noImplicitAny": false,
@@ -16,6 +17,8 @@
     "src/index.ts",
     "src/router.ts",
     "src/recognize.ts",
+    "src/resolve.ts",
+    "src/create_router_state.ts",
     "src/router.ts",
     "src/config.ts",
     "src/router_outlet_map.ts",
@@ -32,6 +35,7 @@
     "test/utils/tree.spec.ts",
     "test/url_serializer.spec.ts",
     "test/recognize.spec.ts",
+    "test/create_router_state.spec.ts",
     "test/create_url_tree.spec.ts",
     "test/router.spec.ts",
     "typings/index.d.ts"


### PR DESCRIPTION
This PR does three things:

- Introduces RouterStateSnapshot and ActivateRouteSnapshot. These two objects are immutable. 
- Makes activation synchronous. This will be important later one when implementing cancelation.
- Add supports for canActivate guard.
- Fixes issues with recognizing index routes

Closes #6