### PR TITLE
fix(router): Guardchecks - do not deactivate matching null treenode

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -392,7 +392,9 @@ class GuardChecks {
       }
       this.traverseChildRoutes(futureNode, currNode, outlet ? outlet.outletMap : null);
     } else {
-      this.deactivateOutletAndItChildren(curr, outlet);
+      if (curr) {    	
+      	this.deactivateOutletAndItChildren(curr, outlet);
+      }
       this.checks.push(new CanActivate(future));
       this.traverseChildRoutes(futureNode, null, outlet ? outlet.outletMap : null);
     }


### PR DESCRIPTION
This fixes Issue-48 [GuardChecks] Cannot read _routeConfig of null. This is caused by a call to deactivateOutletAndItChildren in traverseRoutes in the case the matching current node is null.
