### PR TITLE
Add Support for Componentless Routes

### DIFF
--- a/src/apply_redirects.ts
+++ b/src/apply_redirects.ts
@@ -35,7 +35,7 @@ function createUrlTree(urlTree: UrlTree, root: UrlSegment): Observable<UrlTree> 
 }
 
 function expandSegment(routes: Route[], segment: UrlSegment, outlet: string): UrlSegment {
-  if (segment.pathsWithParams.length === 0 && Object.keys(segment.children).length > 0) {
+  if (segment.pathsWithParams.length === 0 && segment.hasChildren()) {
     return new UrlSegment([], expandSegmentChildren(routes, segment));
   } else {
     return expandPathsWithParams(segment, routes, segment.pathsWithParams, outlet, true);
@@ -119,7 +119,7 @@ function matchPathsWithParamsAgainstRoute(
       return new UrlSegment(consumedPaths, {});
 
       // TODO: check that the right segment is present
-    } else if (slicedPath.length === 0 && Object.keys(segment.children).length > 0) {
+    } else if (slicedPath.length === 0 && segment.hasChildren()) {
       const children = expandSegmentChildren(childConfig, segment);
       return new UrlSegment(consumedPaths, children);
 
@@ -136,7 +136,7 @@ function match(segment: UrlSegment, route: Route, paths: UrlPathWithParams[]): {
   positionalParamSegments: {[k: string]: UrlPathWithParams}
 } {
   if (route.path === '') {
-    if (route.terminal && (Object.keys(segment.children).length > 0 || paths.length > 0)) {
+    if (route.terminal && (segment.hasChildren() || paths.length > 0)) {
       throw new NoMatch();
     } else {
       return {consumedPaths: [], lastChild: 0, positionalParamSegments: {}};
@@ -165,7 +165,7 @@ function match(segment: UrlSegment, route: Route, paths: UrlPathWithParams[]): {
     currentIndex++;
   }
 
-  if (route.terminal && (Object.keys(segment.children).length > 0 || currentIndex < paths.length)) {
+  if (route.terminal && (segment.hasChildren() || currentIndex < paths.length)) {
     throw new NoMatch();
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,10 +26,15 @@ function validateNode(route: Route): void {
     throw new Error(
         `Invalid configuration of route '${route.path}': redirectTo and component cannot be used together`);
   }
+  if (route.redirectTo === undefined && !route.component && !route.children) {
+    throw new Error(
+        `Invalid configuration of route '${route.path}': component, redirectTo, children must be provided`);
+  }
   if (route.path === undefined) {
     throw new Error(`Invalid route configuration: routes must have path specified`);
   }
   if (route.path.startsWith('/')) {
-    throw new Error(`Invalid route configuration of route '${route.path}': path cannot start with a slash`);
+    throw new Error(
+        `Invalid route configuration of route '${route.path}': path cannot start with a slash`);
   }
 }

--- a/src/create_url_tree.ts
+++ b/src/create_url_tree.ts
@@ -139,7 +139,7 @@ function updateSegment(segment: UrlSegment, startIndex: number, commands: any[])
   if (!segment) {
     segment = new UrlSegment([], {});
   }
-  if (segment.pathsWithParams.length === 0 && Object.keys(segment.children).length > 0) {
+  if (segment.pathsWithParams.length === 0 && segment.hasChildren()) {
     return updateSegmentChildren(segment, startIndex, commands);
   }
   const m = prefixedWith(segment, startIndex, commands);
@@ -147,7 +147,7 @@ function updateSegment(segment: UrlSegment, startIndex: number, commands: any[])
 
   if (m.match && slicedCommands.length === 0) {
     return new UrlSegment(segment.pathsWithParams, {});
-  } else if (m.match && Object.keys(segment.children).length === 0) {
+  } else if (m.match && !segment.hasChildren()) {
     return createNewSegment(segment, startIndex, commands);
   } else if (m.match) {
     return updateSegmentChildren(segment, 0, slicedCommands);

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -17,17 +17,25 @@ export function resolve(
 function resolveNode(
     resolver: ComponentResolver, node: TreeNode<ActivatedRouteSnapshot>): Observable<any> {
   if (node.children.length === 0) {
-    return fromPromise(resolver.resolveComponent(<any>node.value.component).then(factory => {
+    return fromPromise(resolveComponent(resolver, <any>node.value).then(factory => {
       node.value._resolvedComponentFactory = factory;
       return node.value;
     }));
 
   } else {
     const c = node.children.map(c => resolveNode(resolver, c).toPromise());
-    return forkJoin(c).map(
-        _ => resolver.resolveComponent(<any>node.value.component).then(factory => {
-          node.value._resolvedComponentFactory = factory;
-          return node.value;
-        }));
+    return forkJoin(c).map(_ => resolveComponent(resolver, <any>node.value).then(factory => {
+      node.value._resolvedComponentFactory = factory;
+      return node.value;
+    }));
+  }
+}
+
+function resolveComponent(
+    resolver: ComponentResolver, snapshot: ActivatedRouteSnapshot): Promise<any> {
+  if (snapshot.component && snapshot._routeConfig) {
+    return resolver.resolveComponent(<any>snapshot.component);
+  } else {
+    return Promise.resolve(null);
   }
 }

--- a/src/url_serializer.ts
+++ b/src/url_serializer.ts
@@ -1,5 +1,5 @@
 import {PRIMARY_OUTLET} from './shared';
-import {UrlPathWithParams, UrlSegment, UrlTree} from './url_tree';
+import {UrlPathWithParams, UrlSegment, UrlTree, mapChildrenIntoArray} from './url_tree';
 import {forEach} from './utils/collection';
 
 
@@ -54,35 +54,19 @@ function serializeSegment(segment: UrlSegment, root: boolean): string {
     } else {
       return `${primary}`;
     }
-  } else if (segment.children[PRIMARY_OUTLET] && !root) {
-    const children = [serializeSegment(segment.children[PRIMARY_OUTLET], false)];
-    forEach(segment.children, (v: UrlSegment, k: string) => {
-      if (k !== PRIMARY_OUTLET) {
-        children.push(`${k}:${serializeSegment(v, false)}`);
+
+  } else if (segment.hasChildren() && !root) {
+    const children = mapChildrenIntoArray(segment, (v: UrlSegment, k: string) => {
+      if (k === PRIMARY_OUTLET) {
+        return [serializeSegment(segment.children[PRIMARY_OUTLET], false)];
+      } else {
+        return [`${k}:${serializeSegment(v, false)}`];
       }
     });
     return `${serializePaths(segment)}/(${children.join('//')})`;
+
   } else {
     return serializePaths(segment);
-  }
-}
-
-function serializeChildren(segment: UrlSegment) {
-  if (segment.children[PRIMARY_OUTLET]) {
-    const primary = serializePaths(segment.children[PRIMARY_OUTLET]);
-
-    const secondary: string[] = [];
-    forEach(segment.children, (v: UrlSegment, k: string) => {
-      if (k !== PRIMARY_OUTLET) {
-        secondary.push(`${k}:${serializePaths(v)}${serializeChildren(v)}`);
-      }
-    });
-    const secondaryStr = secondary.length > 0 ? `(${secondary.join('//')})` : '';
-    const primaryChildren = serializeChildren(segment.children[PRIMARY_OUTLET]);
-    const primaryChildrenStr: string = primaryChildren ? `/${primaryChildren}` : '';
-    return `${primary}${secondaryStr}${primaryChildrenStr}`;
-  } else {
-    return '';
   }
 }
 

--- a/src/url_tree.ts
+++ b/src/url_tree.ts
@@ -74,6 +74,8 @@ export class UrlSegment {
     forEach(children, (v: any, k: any) => v.parent = this);
   }
 
+  hasChildren(): boolean { return Object.keys(this.children).length > 0; }
+
   toString(): string { return serializePaths(this); }
 }
 

--- a/test/apply_redirects.spec.ts
+++ b/test/apply_redirects.spec.ts
@@ -125,6 +125,21 @@ describe('applyRedirects', () => {
     });
   });
 
+  xit("should support redirects with both main and aux", () => {
+    checkRedirect([
+      {path: 'a', children: [
+        {path: 'b', component: ComponentB},
+        {path: '', redirectTo: 'b'},
+
+        {path: 'c', component: ComponentC, outlet: 'aux'},
+        {path: '', redirectTo: 'c', outlet: 'aux'}
+      ]},
+      {path: 'a', redirectTo: ''}
+    ], "a", (t:UrlTree) => {
+      compareTrees(t, tree('a/(b//aux:c)'));
+    });
+  });
+
   it("should redirect empty path route only when terminal", () => {
     const config = [
       {path: 'a', component: ComponentA, children: [

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -37,6 +37,14 @@ describe('config', () => {
       }).toThrowError(`Invalid route configuration: routes must have path specified`);
     });
 
+    it("should throw when none of component and children or direct are missing", () => {
+      expect(() => {
+        validateConfig([
+          {path: 'a'}
+        ]);
+      }).toThrowError(`Invalid configuration of route 'a': component, redirectTo, children must be provided`);
+    });
+
     it("should throw when path starts with a slash", () => {
       expect(() => {
         validateConfig([

--- a/test/create_router_state.spec.ts
+++ b/test/create_router_state.spec.ts
@@ -44,6 +44,32 @@ describe('create router state', () => {
     expect(prevC[1]).not.toBe(currC[1]);
     checkActivatedRoute(currC[1], ComponentC, 'left');
   });
+
+  it('should handle componentless routes', () => {
+    const config = [
+      { path: 'a/:id', children: [
+        { path: 'b', component: ComponentA },
+        { path: 'c', component: ComponentB, outlet: 'right' }
+      ] }
+    ];
+
+
+    const prevState = createRouterState(createState(config, "a/1;p=11/(b//right:c)"), emptyState());
+    advanceState(prevState);
+    const state = createRouterState(createState(config, "a/2;p=22/(b//right:c)"), prevState);
+
+    expect(prevState.root).toBe(state.root);
+    const prevP = prevState.firstChild(prevState.root);
+    const currP = state.firstChild(state.root);
+    expect(prevP).toBe(currP);
+
+    const prevC = prevState.children(prevP);
+    const currC = state.children(currP);
+
+    expect(currP._futureSnapshot.params).toEqual({id: '2', p: '22'});
+    checkActivatedRoute(currC[0], ComponentA);
+    checkActivatedRoute(currC[1], ComponentB, 'right');
+  });
 });
 
 function advanceState(state: RouterState): void {

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -1,0 +1,49 @@
+import {DefaultUrlSerializer} from '../src/url_serializer';
+import {UrlTree, UrlSegment} from '../src/url_tree';
+import {RouterStateSnapshot} from '../src/router_state';
+import {recognize} from '../src/recognize';
+import {resolve} from '../src/resolve';
+import {RouterConfig} from '../src/config';
+
+describe('resolve', () => {
+  it('should resolve components', () => {
+    checkResolve([
+      {path: 'a', component: "ComponentA"}
+    ], "a", {ComponentA: 'ResolvedComponentA'}, (resolved:RouterStateSnapshot) => {
+      expect(resolved.firstChild(resolved.root)._resolvedComponentFactory).toEqual('ResolvedComponentA');
+    });
+  });
+
+  it('should not resolve componentless routes', () => {
+    checkResolve([
+      {path: 'a', children: []}
+    ], "a", {}, (resolved:RouterStateSnapshot) => {
+      expect(resolved.firstChild(resolved.root)._resolvedComponentFactory).toEqual(null);
+    });
+  });
+});
+
+function checkResolve(config: RouterConfig, url: string, resolved: {[k:string]:string}, callback: any): void {
+  const resolver = {
+    resolveComponent: (component:string):Promise<any> => {
+      if (resolved[component]) {
+        return Promise.resolve(resolved[component]);
+      } else {
+        return Promise.reject("unknown component");
+      }
+    }
+  };
+
+  recognize(RootComponent, config, tree(url), url).mergeMap(s => resolve(<any>resolver, s)).subscribe(callback, e => {
+    throw e;
+  });
+}
+
+function tree(url: string): UrlTree {
+  return new DefaultUrlSerializer().parse(url);
+}
+
+class RootComponent {}
+class ComponentA {}
+class ComponentB {}
+class ComponentC {}

--- a/test/url_serializer.spec.ts
+++ b/test/url_serializer.spec.ts
@@ -28,6 +28,33 @@ describe('url serializer', () => {
     expect(url.serialize(tree)).toEqual("/one/two(left:three//right:four)");
   });
 
+  it("should parse segments with empty paths", () => {
+    const tree = url.parse("/one/two/(;a=1//right:;b=2)");
+
+    const c = tree.root.children[PRIMARY_OUTLET];
+    expectSegment(tree.root.children[PRIMARY_OUTLET], "one/two", true);
+
+    expect(c.children[PRIMARY_OUTLET].pathsWithParams[0].path).toEqual('');
+    expect(c.children[PRIMARY_OUTLET].pathsWithParams[0].parameters).toEqual({a: '1'});
+
+    expect(c.children['right'].pathsWithParams[0].path).toEqual('');
+    expect(c.children['right'].pathsWithParams[0].parameters).toEqual({b: '2'});
+
+    expect(url.serialize(tree)).toEqual("/one/two/(;a=1//right:;b=2)");
+  });
+
+  it("should parse segments with empty paths (only aux)", () => {
+    const tree = url.parse("/one/two/(right:;b=2)");
+
+    const c = tree.root.children[PRIMARY_OUTLET];
+    expectSegment(tree.root.children[PRIMARY_OUTLET], "one/two", true);
+
+    expect(c.children['right'].pathsWithParams[0].path).toEqual('');
+    expect(c.children['right'].pathsWithParams[0].parameters).toEqual({b: '2'});
+
+    expect(url.serialize(tree)).toEqual("/one/two/(right:;b=2)");
+  });
+
   it("should parse scoped secondary segments", () => {
     const tree = url.parse("/one/(two//left:three)");
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "test/url_tree.spec.ts",
     "test/utils/tree.spec.ts",
     "test/url_serializer.spec.ts",
+    "test/resolve.spec.ts",
     "test/apply_redirects.spec.ts",
     "test/recognize.spec.ts",
     "test/create_router_state.spec.ts",


### PR DESCRIPTION
Closes #37

It is useful at times have the ability to share parameters between siblings. Say we have two components ChildCmp and AuxCmp that we want to put next to each other and both of them require some sort of id parameter.

One way to do it would be to have one sibling have the id parameter, and to have the second sibling get the parameter from the first one. Another way would be to have a bogus parent component that have the id parameter, so both the siblings can get it from their parent. Both the approaches are not ideal.

Componentless routes allow you to specify a chunk of url that will be used to created an activated route. But that activated route won't be placed anywhere in the DOM. 

For instance:

```
[
  { path: 'parent/:id', children: [
     { path: 'a', component: ChildCmp },
     { path: 'b', component: AuxChild, outlet: 'aux' }
   ] }
]
```

When navigating to `parent/10(a//aux:b)`, the router will create three activated routes:

```
Parent =>
   a
   b
```

And since the parent route is componentless, it won't be placed anywhere in the dom. In addition, both a and b will get the id parameter merged into their map of parameters. This allows ChildCmp and AuxCmp to share certain parametesr. But they still can have their own params.  `parent/10;shared=1(a;belongsToA=2//aux:b;belongsToB=2)`

This is also useful, when the child components have empty paths:

```
[
  { path: 'parent/:id', children: [
     { path: '', component: ChildCmp },
     { path: '', component: AuxChild, outlet: 'aux' }
   ] }
]
```

In this case, navigating to `parent/10` will activate the two child components.